### PR TITLE
Redesign Insights tab with sub-navigation and richer metrics

### DIFF
--- a/auto-focus/Models/InsightsDataProvider.swift
+++ b/auto-focus/Models/InsightsDataProvider.swift
@@ -345,4 +345,125 @@ class InsightsDataProvider {
         )
     }
 
+    func disruptionOverTime(timeframe: Timeframe, selectedDate: Date) -> [HourlyDisruptionData] {
+        let bounds = dateBounds(timeframe: timeframe, selectedDate: selectedDate)
+        guard let events = try? appEventRepo.fetchEvents(since: bounds.start, until: bounds.end) else {
+            return []
+        }
+        let focusBundleIDs = Set(focusManager.focusApps.map(\.bundleIdentifier))
+        let focusDomains = focusManager.focusURLs
+
+        switch timeframe {
+        case .day:
+            return ActivityInsightsService.calculateHourlyDisruptions(
+                events: events, focusBundleIDs: focusBundleIDs, focusDomains: focusDomains
+            )
+        case .week:
+            let weekStart = Calendar.current.startOfWeek(for: selectedDate)
+            return ActivityInsightsService.calculateDailyDisruptions(
+                events: events, focusBundleIDs: focusBundleIDs, focusDomains: focusDomains, weekStart: weekStart
+            )
+        }
+    }
+
+    // MARK: - Focus Quality Metrics
+
+    func longestSession(timeframe: Timeframe, selectedDate: Date) -> FocusSession? {
+        relevantSessions(timeframe: timeframe, selectedDate: selectedDate)
+            .max(by: { $0.duration < $1.duration })
+    }
+
+    func averageSessionLength(timeframe: Timeframe, selectedDate: Date) -> TimeInterval {
+        let sessions = relevantSessions(timeframe: timeframe, selectedDate: selectedDate)
+        guard !sessions.isEmpty else { return 0 }
+        return sessions.reduce(0) { $0 + $1.duration } / Double(sessions.count)
+    }
+
+    func deepFocusSessionCount(timeframe: Timeframe, selectedDate: Date, thresholdMinutes: Int = 25) -> (deep: Int, total: Int) {
+        let sessions = relevantSessions(timeframe: timeframe, selectedDate: selectedDate)
+        let threshold = TimeInterval(thresholdMinutes * 60)
+        let deep = sessions.filter { $0.duration >= threshold }.count
+        return (deep: deep, total: sessions.count)
+    }
+
+    func contextSwitchesPerSession(timeframe: Timeframe, selectedDate: Date) -> Double {
+        let sessions = relevantSessions(timeframe: timeframe, selectedDate: selectedDate)
+        guard !sessions.isEmpty else { return 0 }
+        let disruptions = disruptionSummary(timeframe: timeframe, selectedDate: selectedDate)
+        return Double(disruptions.totalSwitches) / Double(sessions.count)
+    }
+
+    func previousPeriodDisruptions(timeframe: Timeframe, selectedDate: Date) -> DisruptionSummary {
+        let calendar = Calendar.current
+        let previousDate: Date
+        switch timeframe {
+        case .day:
+            previousDate = calendar.date(byAdding: .day, value: -1, to: selectedDate) ?? selectedDate
+        case .week:
+            previousDate = calendar.date(byAdding: .day, value: -7, to: selectedDate) ?? selectedDate
+        }
+        return disruptionSummary(timeframe: timeframe, selectedDate: previousDate)
+    }
+
+    // MARK: - Focus Score
+
+    func focusScore(timeframe: Timeframe, selectedDate: Date) -> Int {
+        let sessions = relevantSessions(timeframe: timeframe, selectedDate: selectedDate)
+        guard !sessions.isEmpty else { return 0 }
+
+        let totalFocus = sessions.reduce(0) { $0 + $1.duration }
+        let allApps = topApps(timeframe: timeframe, selectedDate: selectedDate, limit: 100)
+        let totalTracked = allApps.reduce(0) { $0 + $1.totalDuration }
+
+        let focusRatio: Double
+        if totalTracked > 0 {
+            focusRatio = min(1.0, totalFocus / totalTracked)
+        } else {
+            focusRatio = 0
+        }
+
+        let avgSession = totalFocus / Double(sessions.count)
+        let sessionDepth = min(1.0, avgSession / 3600.0)
+
+        let calendar = Calendar.current
+        let consistencyDays: Double
+        switch timeframe {
+        case .day:
+            consistencyDays = sessions.isEmpty ? 0 : 1.0
+        case .week:
+            let weekStart = calendar.startOfWeek(for: selectedDate)
+            let daysWithSessions = Set((0..<7).compactMap { offset -> Int? in
+                let date = calendar.date(byAdding: .day, value: offset, to: weekStart)!
+                return sessionsForDate(date).isEmpty ? nil : offset
+            })
+            consistencyDays = Double(daysWithSessions.count) / 7.0
+        }
+
+        let disruptions = disruptionSummary(timeframe: timeframe, selectedDate: selectedDate)
+        let switchRate = sessions.isEmpty ? 1.0 : Double(disruptions.totalSwitches) / Double(sessions.count)
+        let lowDistraction = max(0, 1.0 - min(1.0, switchRate / 10.0))
+
+        let score = focusRatio * 0.4 + sessionDepth * 0.3 + consistencyDays * 0.15 + lowDistraction * 0.15
+        return min(100, Int(score * 100))
+    }
+
+    // MARK: - Focus vs Other Split
+
+    func focusVsOtherRatio(timeframe: Timeframe, selectedDate: Date) -> (focusDuration: TimeInterval, otherDuration: TimeInterval) {
+        let allApps = topApps(timeframe: timeframe, selectedDate: selectedDate, limit: 100)
+        let focusBundleIDs = Set(focusManager.focusApps.map(\.bundleIdentifier))
+
+        var focusDuration: TimeInterval = 0
+        var otherDuration: TimeInterval = 0
+
+        for app in allApps {
+            if focusBundleIDs.contains(app.bundleIdentifier) {
+                focusDuration += app.totalDuration
+            } else {
+                otherDuration += app.totalDuration
+            }
+        }
+
+        return (focusDuration: focusDuration, otherDuration: otherDuration)
+    }
 }

--- a/auto-focus/Services/ActivityInsightsService.swift
+++ b/auto-focus/Services/ActivityInsightsService.swift
@@ -5,6 +5,13 @@ struct DisruptionSummary {
     let distractors: [(name: String, count: Int)]
 }
 
+struct HourlyDisruptionData: Identifiable {
+    let id = UUID()
+    let bucket: Int
+    let label: String
+    let switches: Int
+}
+
 struct ActivityInsightsService {
     static func calculateDisruptions(
         events: [AppEvent],
@@ -39,6 +46,78 @@ struct ActivityInsightsService {
         return DisruptionSummary(totalSwitches: totalSwitches, distractors: sorted)
     }
 
+    static func calculateHourlyDisruptions(
+        events: [AppEvent],
+        focusBundleIDs: Set<String>,
+        focusDomains: [FocusURL]
+    ) -> [HourlyDisruptionData] {
+        let calendar = Calendar.current
+        var buckets = Array(repeating: 0, count: 24)
+
+        guard events.count >= 2 else {
+            return (0..<24).map { HourlyDisruptionData(bucket: $0, label: String(format: "%02d", $0), switches: 0) }
+        }
+
+        for i in 0..<(events.count - 1) {
+            let current = events[i]
+            let next = events[i + 1]
+
+            let currentIsFocus = isInFocusContext(event: current, focusBundleIDs: focusBundleIDs, focusDomains: focusDomains)
+            let nextIsFocus = isInFocusContext(event: next, focusBundleIDs: focusBundleIDs, focusDomains: focusDomains)
+
+            if currentIsFocus && !nextIsFocus {
+                let hour = calendar.component(.hour, from: next.timestamp)
+                buckets[hour] += 1
+            }
+        }
+
+        return (0..<24).map { hour in
+            HourlyDisruptionData(bucket: hour, label: String(format: "%02d", hour), switches: buckets[hour])
+        }
+    }
+
+    static func calculateDailyDisruptions(
+        events: [AppEvent],
+        focusBundleIDs: Set<String>,
+        focusDomains: [FocusURL],
+        weekStart: Date
+    ) -> [HourlyDisruptionData] {
+        let calendar = Calendar.current
+        var buckets = Array(repeating: 0, count: 7)
+
+        guard events.count >= 2 else {
+            return (0..<7).map { offset in
+                let date = calendar.date(byAdding: .day, value: offset, to: weekStart)!
+                let weekday = calendar.component(.weekday, from: date)
+                let symbol = String(calendar.shortWeekdaySymbols[weekday - 1].prefix(3))
+                return HourlyDisruptionData(bucket: offset, label: symbol, switches: 0)
+            }
+        }
+
+        for i in 0..<(events.count - 1) {
+            let current = events[i]
+            let next = events[i + 1]
+
+            let currentIsFocus = isInFocusContext(event: current, focusBundleIDs: focusBundleIDs, focusDomains: focusDomains)
+            let nextIsFocus = isInFocusContext(event: next, focusBundleIDs: focusBundleIDs, focusDomains: focusDomains)
+
+            if currentIsFocus && !nextIsFocus {
+                let dayStart = calendar.startOfDay(for: next.timestamp)
+                let dayOffset = calendar.dateComponents([.day], from: calendar.startOfDay(for: weekStart), to: dayStart).day ?? 0
+                if dayOffset >= 0 && dayOffset < 7 {
+                    buckets[dayOffset] += 1
+                }
+            }
+        }
+
+        return (0..<7).map { offset in
+            let date = calendar.date(byAdding: .day, value: offset, to: weekStart)!
+            let weekday = calendar.component(.weekday, from: date)
+            let symbol = String(calendar.shortWeekdaySymbols[weekday - 1].prefix(3))
+            return HourlyDisruptionData(bucket: offset, label: symbol, switches: buckets[offset])
+        }
+    }
+
     private static func isInFocusContext(
         event: AppEvent,
         focusBundleIDs: Set<String>,
@@ -61,6 +140,6 @@ struct ActivityInsightsService {
         if let domain = event.domain {
             return domain
         }
-        return event.appName ?? event.bundleIdentifier
+        return BundleNameMapper.displayName(bundleIdentifier: event.bundleIdentifier, appName: event.appName)
     }
 }

--- a/auto-focus/Utilities/BundleNameMapper.swift
+++ b/auto-focus/Utilities/BundleNameMapper.swift
@@ -1,0 +1,41 @@
+import AppKit
+
+struct BundleNameMapper {
+    private static let friendlyNames: [String: String] = [
+        "com.apple.loginwindow": "Lock Screen",
+        "com.apple.finder": "Finder",
+        "com.apple.systempreferences": "System Settings",
+        "com.apple.SystemPreferences": "System Settings",
+        "com.apple.Safari": "Safari",
+        "com.apple.Terminal": "Terminal",
+        "com.apple.dt.Xcode": "Xcode",
+        "com.apple.mail": "Mail",
+        "com.apple.iCal": "Calendar",
+        "com.apple.Notes": "Notes",
+        "com.apple.MobileSMS": "Messages",
+        "com.apple.FaceTime": "FaceTime",
+        "com.apple.Preview": "Preview",
+        "com.apple.ActivityMonitor": "Activity Monitor",
+        "com.apple.ScreenSaver.Engine": "Screen Saver",
+        "com.apple.dock": "Dock",
+        "com.apple.Spotlight": "Spotlight",
+    ]
+
+    static func displayName(bundleIdentifier: String, appName: String?) -> String {
+        if let friendly = friendlyNames[bundleIdentifier] {
+            return friendly
+        }
+        if let name = appName, !name.isEmpty {
+            return name
+        }
+        let components = bundleIdentifier.split(separator: ".")
+        return components.last.map(String.init) ?? bundleIdentifier
+    }
+
+    static func appIcon(for bundleIdentifier: String) -> NSImage? {
+        guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) else {
+            return nil
+        }
+        return NSWorkspace.shared.icon(forFile: appURL.path)
+    }
+}

--- a/auto-focus/Views/InsightsView.swift
+++ b/auto-focus/Views/InsightsView.swift
@@ -1,21 +1,17 @@
 import Charts
 import SwiftUI
 
-struct InsightsGraphsContainerView: View {
-    @ObservedObject var dataProvider: InsightsViewModel
+// MARK: - Insights Sub-Tab
 
-    var body: some View {
-        GroupBox {
-            VStack(alignment: .leading, spacing: 12) {
-                WeeklyBarChartView(dataProvider: dataProvider)
+enum InsightsSubTab: String, CaseIterable, Identifiable {
+    case summary = "Summary"
+    case activity = "Activity"
+    case focusQuality = "Focus Quality"
 
-                if dataProvider.selectedTimeframe == .day {
-                    HourlyBarChartView(dataProvider: dataProvider)
-                }
-            }
-        }
-    }
+    var id: String { rawValue }
 }
+
+// MARK: - Shared Chart Components
 
 struct WeeklyBarChartView: View {
     @ObservedObject var dataProvider: InsightsViewModel
@@ -304,7 +300,172 @@ struct ProductivityMetricsView: View {
     }
 }
 
-// MARK: - Activity Breakdown
+// MARK: - Focus Score Ring
+
+struct FocusScoreView: View {
+    let score: Int
+
+    private var scoreColor: Color {
+        switch score {
+        case 0..<30: return .red
+        case 30..<60: return .orange
+        case 60..<80: return .yellow
+        default: return .green
+        }
+    }
+
+    var body: some View {
+        GroupBox {
+            HStack(spacing: 20) {
+                ZStack {
+                    Circle()
+                        .stroke(Color.gray.opacity(0.15), lineWidth: 8)
+                        .frame(width: 80, height: 80)
+
+                    Circle()
+                        .trim(from: 0, to: CGFloat(score) / 100.0)
+                        .stroke(scoreColor, style: StrokeStyle(lineWidth: 8, lineCap: .round))
+                        .frame(width: 80, height: 80)
+                        .rotationEffect(.degrees(-90))
+
+                    Text("\(score)")
+                        .font(.system(size: 24, weight: .bold))
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Focus Score")
+                        .font(.headline)
+                    Text("Based on focus ratio, session depth, consistency, and low distraction.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+// MARK: - Summary Pane
+
+struct InsightsSummaryPane: View {
+    @ObservedObject var dataProvider: InsightsViewModel
+
+    var body: some View {
+        VStack(spacing: 10) {
+            GroupBox {
+                VStack {
+                    Text("You've focussed for").font(.title2)
+                        .fontDesign(.default)
+                        .foregroundStyle(.secondary)
+                    let totalSeconds = Int(dataProvider.totalFocusTimeThisMonth)
+                    let totalMinutes = Int(totalSeconds / 60)
+
+                    Text("\(TimeFormatter.duration(totalMinutes)) this month")
+                        .font(.title)
+                        .fontWeight(.bold)
+                    Text("Here you can find your curated focus insights. From daily to weekly detailed views, your most productive times and more.")
+                        .font(.callout)
+                        .fontDesign(.default)
+                        .fontWeight(.regular)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .padding(.horizontal, 40)
+                .padding(.vertical)
+                .frame(maxWidth: .infinity)
+            }
+
+            FocusScoreView(score: dataProvider.focusScore)
+
+            GroupBox {
+                VStack(alignment: .leading, spacing: 8) {
+                    ProductivityMetricsView(dataProvider: dataProvider)
+                }
+                .padding(8)
+            }
+
+            GroupBox {
+                VStack(alignment: .leading, spacing: 8) {
+                    InsightsHeaderView(dataProvider: dataProvider)
+                    FocusTimeOverviewView(dataProvider: dataProvider)
+
+                    GroupBox {
+                        VStack(alignment: .leading, spacing: 12) {
+                            WeeklyBarChartView(dataProvider: dataProvider)
+
+                            if dataProvider.selectedTimeframe == .day {
+                                HourlyBarChartView(dataProvider: dataProvider)
+                            }
+                        }
+                    }
+
+                    HStack {
+                        Text("Number of sessions")
+                            .font(.body)
+                        Spacer()
+                        Text("\(dataProvider.relevantSessions.count)")
+                            .font(.body)
+                    }
+                    .padding(.top, 8)
+                }
+                .padding(8)
+            }
+        }
+    }
+}
+
+// MARK: - Activity Pane
+
+struct FocusRatioBarView: View {
+    let focusDuration: TimeInterval
+    let otherDuration: TimeInterval
+
+    private var total: TimeInterval { focusDuration + otherDuration }
+    private var focusPercent: Int {
+        total > 0 ? Int((focusDuration / total) * 100) : 0
+    }
+    private var otherPercent: Int { 100 - focusPercent }
+
+    var body: some View {
+        if total > 0 {
+            GroupBox {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Focus vs. Other")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+
+                    GeometryReader { geo in
+                        HStack(spacing: 2) {
+                            if focusDuration > 0 {
+                                RoundedRectangle(cornerRadius: 4)
+                                    .fill(Color.blue)
+                                    .frame(width: geo.size.width * CGFloat(focusDuration / total))
+                            }
+                            if otherDuration > 0 {
+                                RoundedRectangle(cornerRadius: 4)
+                                    .fill(Color.gray.opacity(0.3))
+                                    .frame(width: geo.size.width * CGFloat(otherDuration / total))
+                            }
+                        }
+                    }
+                    .frame(height: 20)
+
+                    HStack(spacing: 16) {
+                        Label("\(focusPercent)% Focus", systemImage: "circle.fill")
+                            .font(.caption)
+                            .foregroundColor(.blue)
+                        Label("\(otherPercent)% Other", systemImage: "circle.fill")
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                    }
+                }
+                .padding(4)
+            }
+        }
+    }
+}
 
 struct ActivityBreakdownView: View {
     @ObservedObject var dataProvider: InsightsViewModel
@@ -313,27 +474,59 @@ struct ActivityBreakdownView: View {
     var body: some View {
         let apps = dataProvider.topApps
         let domains = dataProvider.topDomains
+        let focusBundleIDs = Set(focusManager.focusApps.map(\.bundleIdentifier))
+        let focusDomains = focusManager.focusURLs
+
+        let focusApps = apps.filter { focusBundleIDs.contains($0.bundleIdentifier) }
+        let otherApps = apps.filter { !focusBundleIDs.contains($0.bundleIdentifier) }
+
+        let focusDomainsList = domains.filter { domain in
+            focusDomains.contains { $0.matches(domain.domain) || $0.matches("https://\(domain.domain)") }
+        }
+        let otherDomainsList = domains.filter { domain in
+            !focusDomains.contains { $0.matches(domain.domain) || $0.matches("https://\(domain.domain)") }
+        }
 
         if apps.isEmpty && domains.isEmpty {
             EmptyView()
         } else {
-            GroupBox("Activity Breakdown") {
-                VStack(alignment: .leading, spacing: 16) {
-                    if !apps.isEmpty {
-                        appSection(apps: apps)
-                    }
-                    if !domains.isEmpty {
-                        domainSection(domains: domains)
+            let totalAppDuration = apps.reduce(0) { $0 + $1.totalDuration }
+            let totalDomainDuration = domains.reduce(0) { $0 + $1.totalDuration }
+
+            VStack(spacing: 10) {
+                if !focusApps.isEmpty || !focusDomainsList.isEmpty {
+                    GroupBox("Focus Activity") {
+                        VStack(alignment: .leading, spacing: 16) {
+                            if !focusApps.isEmpty {
+                                appSection(apps: focusApps, totalDuration: totalAppDuration, accentColor: .blue)
+                            }
+                            if !focusDomainsList.isEmpty {
+                                domainSection(domains: focusDomainsList, totalDuration: totalDomainDuration, accentColor: .blue)
+                            }
+                        }
+                        .padding(4)
                     }
                 }
-                .padding(4)
+
+                if !otherApps.isEmpty || !otherDomainsList.isEmpty {
+                    GroupBox("Other Activity") {
+                        VStack(alignment: .leading, spacing: 16) {
+                            if !otherApps.isEmpty {
+                                appSection(apps: otherApps, totalDuration: totalAppDuration, accentColor: .gray)
+                            }
+                            if !otherDomainsList.isEmpty {
+                                domainSection(domains: otherDomainsList, totalDuration: totalDomainDuration, accentColor: .purple)
+                            }
+                        }
+                        .padding(4)
+                    }
+                }
             }
         }
     }
 
-    private func appSection(apps: [AppUsageSummary]) -> some View {
+    private func appSection(apps: [AppUsageSummary], totalDuration: TimeInterval, accentColor: Color) -> some View {
         let maxDuration = apps.first?.totalDuration ?? 1
-        let focusBundleIDs = Set(focusManager.focusApps.map(\.bundleIdentifier))
 
         return VStack(alignment: .leading, spacing: 6) {
             Text("Apps")
@@ -341,39 +534,49 @@ struct ActivityBreakdownView: View {
                 .foregroundColor(.secondary)
 
             ForEach(apps, id: \.bundleIdentifier) { app in
+                let displayName = BundleNameMapper.displayName(bundleIdentifier: app.bundleIdentifier, appName: app.appName)
+                let percent = totalDuration > 0 ? Int((app.totalDuration / totalDuration) * 100) : 0
+
                 HStack(spacing: 8) {
-                    if focusBundleIDs.contains(app.bundleIdentifier) {
-                        Circle()
-                            .fill(Color.blue)
-                            .frame(width: 6, height: 6)
+                    if let icon = BundleNameMapper.appIcon(for: app.bundleIdentifier) {
+                        Image(nsImage: icon)
+                            .resizable()
+                            .frame(width: 18, height: 18)
                     } else {
-                        Spacer().frame(width: 6)
+                        Image(systemName: "app.fill")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .frame(width: 18, height: 18)
                     }
 
-                    Text(app.appName ?? app.bundleIdentifier)
+                    Text(displayName)
                         .font(.callout)
                         .frame(width: 120, alignment: .leading)
                         .lineLimit(1)
 
                     GeometryReader { geo in
                         RoundedRectangle(cornerRadius: 3)
-                            .fill(Color.blue.opacity(0.5))
+                            .fill(accentColor.opacity(0.5))
                             .frame(width: max(4, geo.size.width * CGFloat(app.totalDuration / maxDuration)))
                     }
                     .frame(height: 14)
 
-                    Text(TimeFormatter.duration(Int(app.totalDuration / 60)))
+                    Text("\(TimeFormatter.duration(Int(app.totalDuration / 60)))")
                         .font(.caption)
                         .foregroundColor(.secondary)
                         .frame(width: 50, alignment: .trailing)
+
+                    Text("\(percent)%")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .frame(width: 30, alignment: .trailing)
                 }
             }
         }
     }
 
-    private func domainSection(domains: [DomainUsageSummary]) -> some View {
+    private func domainSection(domains: [DomainUsageSummary], totalDuration: TimeInterval, accentColor: Color) -> some View {
         let maxDuration = domains.first?.totalDuration ?? 1
-        let focusDomains = focusManager.focusURLs
 
         return VStack(alignment: .leading, spacing: 6) {
             Text("Websites")
@@ -381,82 +584,228 @@ struct ActivityBreakdownView: View {
                 .foregroundColor(.secondary)
 
             ForEach(domains, id: \.domain) { domain in
-                let isFocusDomain = focusDomains.contains { $0.matches(domain.domain) || $0.matches("https://\(domain.domain)") }
-                HStack(spacing: 8) {
-                    if isFocusDomain {
-                        Circle()
-                            .fill(Color.blue)
-                            .frame(width: 6, height: 6)
-                    } else {
-                        Spacer().frame(width: 6)
-                    }
+                let percent = totalDuration > 0 ? Int((domain.totalDuration / totalDuration) * 100) : 0
 
+                HStack(spacing: 8) {
                     Image(systemName: "globe")
                         .font(.caption)
                         .foregroundColor(.secondary)
+                        .frame(width: 18)
 
                     Text(domain.domain)
                         .font(.callout)
-                        .frame(width: 110, alignment: .leading)
+                        .frame(width: 120, alignment: .leading)
                         .lineLimit(1)
 
                     GeometryReader { geo in
                         RoundedRectangle(cornerRadius: 3)
-                            .fill(Color.purple.opacity(0.5))
+                            .fill(accentColor.opacity(0.5))
                             .frame(width: max(4, geo.size.width * CGFloat(domain.totalDuration / maxDuration)))
                     }
                     .frame(height: 14)
 
-                    Text(TimeFormatter.duration(Int(domain.totalDuration / 60)))
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .frame(width: 50, alignment: .trailing)
+                    VStack(alignment: .trailing, spacing: 0) {
+                        Text(TimeFormatter.duration(Int(domain.totalDuration / 60)))
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        if domain.visitCount > 0 {
+                            Text("\(domain.visitCount) visits")
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
+                    .frame(width: 55, alignment: .trailing)
+
+                    Text("\(percent)%")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .frame(width: 30, alignment: .trailing)
                 }
             }
         }
     }
 }
 
-// MARK: - Context Switches
+struct InsightsActivityPane: View {
+    @ObservedObject var dataProvider: InsightsViewModel
+
+    var body: some View {
+        VStack(spacing: 10) {
+            InsightsHeaderView(dataProvider: dataProvider)
+                .padding(.horizontal, 4)
+
+            let ratio = dataProvider.focusVsOtherRatio
+            FocusRatioBarView(focusDuration: ratio.focusDuration, otherDuration: ratio.otherDuration)
+
+            ActivityBreakdownView(dataProvider: dataProvider)
+        }
+    }
+}
+
+// MARK: - Focus Quality Pane
+
+struct DisruptionChartView: View {
+    let data: [HourlyDisruptionData]
+    let isHourly: Bool
+
+    var body: some View {
+        let hasData = data.contains { $0.switches > 0 }
+        if hasData {
+            GroupBox {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(isHourly ? "Switches by Hour" : "Switches by Day")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+
+                    Chart {
+                        ForEach(data) { item in
+                            if item.switches > 0 {
+                                BarMark(
+                                    x: .value("Time", item.label),
+                                    y: .value("Switches", item.switches)
+                                )
+                                .foregroundStyle(Color.orange.opacity(0.7))
+                            }
+                        }
+                    }
+                    .chartXAxis {
+                        if isHourly {
+                            AxisMarks(values: ["00", "06", "12", "18", "23"]) { value in
+                                AxisValueLabel()
+                            }
+                        } else {
+                            AxisMarks { _ in
+                                AxisValueLabel()
+                            }
+                        }
+                    }
+                    .frame(height: 80)
+                }
+                .padding(4)
+            }
+        }
+    }
+}
 
 struct ContextSwitchesView: View {
     @ObservedObject var dataProvider: InsightsViewModel
 
     var body: some View {
         let summary = dataProvider.disruptionSummary
-        if summary.totalSwitches > 0 {
-            GroupBox("Context Switches") {
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack(alignment: .firstTextBaseline) {
-                        Text("\(summary.totalSwitches)")
-                            .font(.system(size: 28, weight: .semibold))
-                        Text("context \(summary.totalSwitches == 1 ? "switch" : "switches")")
-                            .font(.body)
-                            .foregroundColor(.secondary)
-                    }
 
-                    if !summary.distractors.isEmpty {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Top distractors")
-                                .font(.subheadline)
+        GroupBox("Context Switches") {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("A context switch happens when you leave a focus app or website and switch to something else. Fewer switches means deeper focus.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text("\(summary.totalSwitches)")
+                        .font(.system(size: 28, weight: .semibold))
+                    Text("context \(summary.totalSwitches == 1 ? "switch" : "switches")")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+
+                    Spacer()
+
+                    let prev = dataProvider.previousPeriodDisruptions
+                    if prev.totalSwitches > 0 {
+                        let delta = summary.totalSwitches - prev.totalSwitches
+                        let pct = Int((Double(delta) / Double(prev.totalSwitches)) * 100)
+                        let label = dataProvider.selectedTimeframe == .day ? "vs yesterday" : "vs last week"
+                        HStack(spacing: 2) {
+                            Image(systemName: delta <= 0 ? "arrow.down.right" : "arrow.up.right")
+                                .font(.caption)
+                                .foregroundColor(delta <= 0 ? .green : .red)
+                            Text("\(abs(pct))% \(label)")
+                                .font(.caption)
                                 .foregroundColor(.secondary)
+                        }
+                    }
+                }
 
-                            ForEach(Array(summary.distractors.prefix(5).enumerated()), id: \.offset) { _, item in
-                                HStack {
-                                    Text(item.name)
-                                        .font(.callout)
-                                        .lineLimit(1)
-                                    Spacer()
-                                    Text("\(item.count)x")
-                                        .font(.callout)
-                                        .foregroundColor(.secondary)
-                                }
+                let chartData = dataProvider.disruptionOverTime
+                DisruptionChartView(data: chartData, isHourly: dataProvider.selectedTimeframe == .day)
+
+                if !summary.distractors.isEmpty {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Top distractors")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+
+                        ForEach(Array(summary.distractors.prefix(5).enumerated()), id: \.offset) { _, item in
+                            HStack {
+                                Text(item.name)
+                                    .font(.callout)
+                                    .lineLimit(1)
+                                Spacer()
+                                Text("\(item.count)x")
+                                    .font(.callout)
+                                    .foregroundColor(.secondary)
                             }
                         }
                     }
                 }
-                .padding(4)
             }
+            .padding(4)
+        }
+    }
+}
+
+struct FocusQualityMetricsView: View {
+    @ObservedObject var dataProvider: InsightsViewModel
+
+    var body: some View {
+        VStack(spacing: 10) {
+            HStack(spacing: 10) {
+                if let longest = dataProvider.longestSession {
+                    MetricCard(
+                        title: "Longest Focus Stretch",
+                        value: TimeFormatter.duration(Int(longest.duration / 60))
+                    )
+                } else {
+                    MetricCard(
+                        title: "Longest Focus Stretch",
+                        value: "—"
+                    )
+                }
+
+                MetricCard(
+                    title: "Avg Session Length",
+                    value: dataProvider.averageSessionLength > 0
+                        ? TimeFormatter.duration(Int(dataProvider.averageSessionLength / 60))
+                        : "—"
+                )
+            }
+
+            HStack(spacing: 10) {
+                let deep = dataProvider.deepFocusSessions
+                MetricCard(
+                    title: "Deep Focus (25m+)",
+                    value: deep.total > 0 ? "\(deep.deep) of \(deep.total)" : "—"
+                )
+
+                MetricCard(
+                    title: "Switches / Session",
+                    value: dataProvider.relevantSessions.isEmpty
+                        ? "—"
+                        : String(format: "%.1f", dataProvider.contextSwitchesPerSession)
+                )
+            }
+        }
+    }
+}
+
+struct InsightsFocusQualityPane: View {
+    @ObservedObject var dataProvider: InsightsViewModel
+
+    var body: some View {
+        VStack(spacing: 10) {
+            InsightsHeaderView(dataProvider: dataProvider)
+                .padding(.horizontal, 4)
+
+            FocusQualityMetricsView(dataProvider: dataProvider)
+            ContextSwitchesView(dataProvider: dataProvider)
         }
     }
 }
@@ -468,6 +817,7 @@ struct InsightsView: View {
     @EnvironmentObject var licenseManager: LicenseManager
     @StateObject private var dataProvider: InsightsViewModel
     @Binding var selectedTab: Int
+    @State private var selectedSubTab: InsightsSubTab = .summary
 
     init(selectedTab: Binding<Int>) {
         _dataProvider = StateObject(wrappedValue: InsightsViewModel(dataProvider: InsightsDataProvider(focusManager: FocusManager.shared)))
@@ -475,97 +825,92 @@ struct InsightsView: View {
     }
 
     var body: some View {
-        ScrollView {
-            VStack(spacing: 10) {
-                GroupBox {
-                    VStack {
-                        Text("You've focussed for").font(.title2)
-                            .fontDesign(.default)
-                            .foregroundStyle(.secondary)
-                        let totalSeconds = Int(dataProvider.totalFocusTimeThisMonth)
-                        let totalMinutes = Int(totalSeconds / 60)
-
-                        Text("\(TimeFormatter.duration(totalMinutes)) this month")
-                            .font(.title)
-                            .fontWeight(.bold)
-                        Text("Here you can find your curated focus insights. From daily to weekly detailed views, your most productive times and more.")
-                            .font(.callout)
-                            .fontDesign(.default)
-                            .fontWeight(.regular)
-                            .foregroundColor(.secondary)
-                            .multilineTextAlignment(.center)
+        VStack(spacing: 0) {
+            if licenseManager.hasValidLicense() {
+                Picker("", selection: $selectedSubTab) {
+                    ForEach(InsightsSubTab.allCases) { tab in
+                        Text(tab.rawValue).tag(tab)
                     }
-                    .padding(.horizontal, 40)
-                    .padding(.vertical)
-                    .frame(maxWidth: .infinity)
                 }
+                .pickerStyle(.segmented)
+                .padding(.horizontal)
+                .padding(.top, 8)
+                .padding(.bottom, 4)
+            }
 
-                if licenseManager.hasValidLicense() {
-                    GroupBox {
-                        VStack(alignment: .leading, spacing: 8) {
-                            ProductivityMetricsView(dataProvider: dataProvider)
+            ScrollView {
+                VStack(spacing: 10) {
+                    if licenseManager.hasValidLicense() {
+                        switch selectedSubTab {
+                        case .summary:
+                            InsightsSummaryPane(dataProvider: dataProvider)
+                        case .activity:
+                            InsightsActivityPane(dataProvider: dataProvider)
+                        case .focusQuality:
+                            InsightsFocusQualityPane(dataProvider: dataProvider)
                         }
-                        .padding(8)
-                    }
+                    } else {
+                        GroupBox {
+                            VStack {
+                                Text("You've focussed for").font(.title2)
+                                    .fontDesign(.default)
+                                    .foregroundStyle(.secondary)
+                                let totalSeconds = Int(dataProvider.totalFocusTimeThisMonth)
+                                let totalMinutes = Int(totalSeconds / 60)
 
-                    GroupBox {
-                        VStack(alignment: .leading, spacing: 8) {
-                            InsightsHeaderView(dataProvider: dataProvider)
-                            FocusTimeOverviewView(dataProvider: dataProvider)
-                            InsightsGraphsContainerView(dataProvider: dataProvider)
+                                Text("\(TimeFormatter.duration(totalMinutes)) this month")
+                                    .font(.title)
+                                    .fontWeight(.bold)
+                                Text("Here you can find your curated focus insights. From daily to weekly detailed views, your most productive times and more.")
+                                    .font(.callout)
+                                    .fontDesign(.default)
+                                    .fontWeight(.regular)
+                                    .foregroundColor(.secondary)
+                                    .multilineTextAlignment(.center)
+                            }
+                            .padding(.horizontal, 40)
+                            .padding(.vertical)
+                            .frame(maxWidth: .infinity)
+                        }
+
+                        GroupBox {
+                            VStack {
+                                Text("You are currently on a free plan of Auto-Focus. To unlock more detailed insights, please upgrade to Auto-Focus+.")
+                                    .font(.callout)
+                                    .fontDesign(.default)
+                                    .fontWeight(.regular)
+                                    .foregroundColor(.secondary)
+                                    .multilineTextAlignment(.center)
+
+                                LicenseBenefitsView()
+                            }
+                            .padding(.horizontal, 40)
+                            .padding(.vertical)
+                            .frame(maxWidth: .infinity)
 
                             HStack {
-                                Text("Number of sessions")
-                                    .font(.body)
+                                Image(systemName: "lock.fill")
+                                    .foregroundColor(.secondary)
+                                Text("Upgrade to Auto-Focus+ for detailed insights")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+
                                 Spacer()
-                                Text("\(dataProvider.relevantSessions.count)")
-                                    .font(.body)
+
+                                Button("Upgrade") {
+                                    selectedTab = 4
+                                }
+                                .controlSize(.small)
                             }
-                            .padding(.top, 8)
+                            .padding(.vertical, 6)
+                            .padding(.horizontal, 8)
+                            .background(Color.secondary.opacity(0.1))
+                            .cornerRadius(6)
                         }
-                        .padding(8)
-                    }
-
-                    ActivityBreakdownView(dataProvider: dataProvider)
-                    ContextSwitchesView(dataProvider: dataProvider)
-                } else {
-                    GroupBox {
-                        VStack {
-                            Text("You are currently on a free plan of Auto-Focus. To unlock more detailed insights, please upgrade to Auto-Focus+.")
-                                .font(.callout)
-                                .fontDesign(.default)
-                                .fontWeight(.regular)
-                                .foregroundColor(.secondary)
-                                .multilineTextAlignment(.center)
-
-                            LicenseBenefitsView()
-                        }
-                        .padding(.horizontal, 40)
-                        .padding(.vertical)
-                        .frame(maxWidth: .infinity)
-
-                        HStack {
-                            Image(systemName: "lock.fill")
-                                .foregroundColor(.secondary)
-                            Text("Upgrade to Auto-Focus+ for detailed insights")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-
-                            Spacer()
-
-                            Button("Upgrade") {
-                                selectedTab = 4 // Navigate to Auto-Focus+ tab
-                            }
-                            .controlSize(.small)
-                        }
-                        .padding(.vertical, 6)
-                        .padding(.horizontal, 8)
-                        .background(Color.secondary.opacity(0.1))
-                        .cornerRadius(6)
                     }
                 }
+                .padding()
             }
-            .padding()
         }
         .onAppear {
             dataProvider.updateFocusManager(focusManager)

--- a/auto-focus/Views/InsightsViewModel.swift
+++ b/auto-focus/Views/InsightsViewModel.swift
@@ -159,6 +159,39 @@ class InsightsViewModel: ObservableObject {
             ?? DisruptionSummary(totalSwitches: 0, distractors: [])
     }
 
+    var disruptionOverTime: [HourlyDisruptionData] {
+        dataProvider?.disruptionOverTime(timeframe: selectedTimeframe, selectedDate: selectedDate) ?? []
+    }
+
+    var previousPeriodDisruptions: DisruptionSummary {
+        dataProvider?.previousPeriodDisruptions(timeframe: selectedTimeframe, selectedDate: selectedDate)
+            ?? DisruptionSummary(totalSwitches: 0, distractors: [])
+    }
+
+    var longestSession: FocusSession? {
+        dataProvider?.longestSession(timeframe: selectedTimeframe, selectedDate: selectedDate)
+    }
+
+    var averageSessionLength: TimeInterval {
+        dataProvider?.averageSessionLength(timeframe: selectedTimeframe, selectedDate: selectedDate) ?? 0
+    }
+
+    var deepFocusSessions: (deep: Int, total: Int) {
+        dataProvider?.deepFocusSessionCount(timeframe: selectedTimeframe, selectedDate: selectedDate) ?? (0, 0)
+    }
+
+    var contextSwitchesPerSession: Double {
+        dataProvider?.contextSwitchesPerSession(timeframe: selectedTimeframe, selectedDate: selectedDate) ?? 0
+    }
+
+    var focusScore: Int {
+        dataProvider?.focusScore(timeframe: selectedTimeframe, selectedDate: selectedDate) ?? 0
+    }
+
+    var focusVsOtherRatio: (focusDuration: TimeInterval, otherDuration: TimeInterval) {
+        dataProvider?.focusVsOtherRatio(timeframe: selectedTimeframe, selectedDate: selectedDate) ?? (0, 0)
+    }
+
     var productiveTimeRange: (startHour: Int, endHour: Int, duration: TimeInterval)? {
         return dataProvider?.calculateProductiveTimeRange()
     }


### PR DESCRIPTION
The single scrolling list was hard to parse and buried useful data. This splits the Insights tab into three panes behind a segmented picker.

**Summary** — keeps hero card, productivity metrics, usage charts; adds a Focus Score ring (0–100) combining focus ratio, session depth, consistency, and distraction rate.

**Activity** — splits apps/websites into Focus vs Other groups, shows app icons, adds percentage and visit-count labels, maps system bundle IDs to friendly names (loginwindow → Lock Screen).

**Focus Quality** — explains what a context switch is, adds a switches-over-time bar chart, trend vs previous period, and four metric cards (longest stretch, avg session, deep focus count, switches per session).

Made with [Cursor](https://cursor.com)