### PR TITLE
Fix horizontal scroll on small viewports

### DIFF
--- a/docs/canceled.html
+++ b/docs/canceled.html
@@ -21,6 +21,7 @@
             background: var(--bg);
             color: var(--text);
             font-family: system-ui, -apple-system, sans-serif;
+            overflow-x: hidden;
         }
 
         .border-brutal {

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -24,6 +24,7 @@
             background: var(--bg);
             color: var(--text);
             font-family: system-ui, -apple-system, sans-serif;
+            overflow-x: hidden;
         }
 
         .border-brutal {

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,6 +32,7 @@
             background: var(--bg);
             color: var(--text);
             font-family: system-ui, -apple-system, sans-serif;
+            overflow-x: hidden;
         }
 
         .border-brutal {

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -24,6 +24,7 @@
             background: var(--bg);
             color: var(--text);
             font-family: system-ui, -apple-system, sans-serif;
+            overflow-x: hidden;
         }
 
         .border-brutal {

--- a/docs/refunds.html
+++ b/docs/refunds.html
@@ -24,6 +24,7 @@
             background: var(--bg);
             color: var(--text);
             font-family: system-ui, -apple-system, sans-serif;
+            overflow-x: hidden;
         }
 
         .border-brutal {

--- a/docs/success.html
+++ b/docs/success.html
@@ -22,6 +22,7 @@
             background: var(--bg);
             color: var(--text);
             font-family: system-ui, -apple-system, sans-serif;
+            overflow-x: hidden;
         }
 
         .border-brutal {

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -24,6 +24,7 @@
             background: var(--bg);
             color: var(--text);
             font-family: system-ui, -apple-system, sans-serif;
+            overflow-x: hidden;
         }
 
         .border-brutal {


### PR DESCRIPTION
Add overflow-x: hidden to body across all marketing pages. The
hero's notification container uses negative right offset and a
scaled transform that overflows the viewport on narrow screens.