### PR TITLE
Add anonymous installation check-in

### DIFF
--- a/auto-focus/Services/InstallationTracker.swift
+++ b/auto-focus/Services/InstallationTracker.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// Sends a daily anonymous check-in so we can count active installations
+/// and see version distribution. No personal data is collected — just a
+/// locally-generated random UUID, app version, macOS version, and license tier.
+///
+/// Fire-and-forget: any failure is silently ignored and never blocks the app.
+class InstallationTracker {
+    static let shared = InstallationTracker()
+
+    static let analyticsEnabledKey = "AutoFocus_AnalyticsEnabled"
+
+    private let logger = AppLogger.network
+    private let userDefaults = UserDefaults.standard
+    private let installationIdKey = "AutoFocus_InstallationID"
+    private let lastCheckInKey = "AutoFocus_LastInstallationCheckIn"
+
+    private let endpoint = "https://auto-focus.app/api/v1/installations/check-in"
+    private let checkInIntervalHours: TimeInterval = 24
+
+    private init() {
+        if userDefaults.object(forKey: Self.analyticsEnabledKey) == nil {
+            userDefaults.set(true, forKey: Self.analyticsEnabledKey)
+        }
+    }
+
+    func checkInIfNeeded(isLicensed: Bool, isBeta: Bool) {
+        guard isEnabled else { return }
+        guard shouldCheckIn else { return }
+
+        let payload: [String: Any] = [
+            "installation_id": installationId,
+            "app_version": appVersion,
+            "os_version": osVersion,
+            "tier": tier(isLicensed: isLicensed, isBeta: isBeta)
+        ]
+
+        Task.detached { [weak self] in
+            await self?.send(payload)
+        }
+    }
+
+    private func send(_ payload: [String: Any]) async {
+        guard let url = URL(string: endpoint) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 10
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+            let (_, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) {
+                userDefaults.set(Date(), forKey: lastCheckInKey)
+                logger.debug("Installation check-in sent", metadata: [
+                    "version": payload["app_version"] as? String ?? "?",
+                    "tier": payload["tier"] as? String ?? "?"
+                ])
+            } else if let http = response as? HTTPURLResponse {
+                logger.debug("Installation check-in non-success (ignored)", metadata: [
+                    "status": String(http.statusCode)
+                ])
+            }
+        } catch {
+            logger.debug("Installation check-in failed (ignored)", metadata: [
+                "error": error.localizedDescription
+            ])
+        }
+    }
+
+    private var isEnabled: Bool {
+        userDefaults.bool(forKey: Self.analyticsEnabledKey)
+    }
+
+    private var shouldCheckIn: Bool {
+        guard let last = userDefaults.object(forKey: lastCheckInKey) as? Date else { return true }
+        return Date().timeIntervalSince(last) >= checkInIntervalHours * 3600
+    }
+
+    private var installationId: String {
+        if let existing = userDefaults.string(forKey: installationIdKey) {
+            return existing
+        }
+        let new = UUID().uuidString
+        userDefaults.set(new, forKey: installationIdKey)
+        return new
+    }
+
+    private var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+    }
+
+    private var osVersion: String {
+        let v = ProcessInfo.processInfo.operatingSystemVersion
+        return "\(v.majorVersion).\(v.minorVersion)"
+    }
+
+    private func tier(isLicensed: Bool, isBeta: Bool) -> String {
+        if isBeta { return "beta" }
+        return isLicensed ? "licensed" : "free"
+    }
+}

--- a/auto-focus/Services/LicenseManager.swift
+++ b/auto-focus/Services/LicenseManager.swift
@@ -142,6 +142,11 @@ class LicenseManager: ObservableObject {
             ])
             enableBetaAccess()
         }
+
+        InstallationTracker.shared.checkInIfNeeded(
+            isLicensed: isLicensed,
+            isBeta: licenseOwner == "Beta User"
+        )
     }
 
     private var betaExpiryDate: Date {

--- a/auto-focus/Views/ConfigurationView.swift
+++ b/auto-focus/Views/ConfigurationView.swift
@@ -214,6 +214,10 @@ struct GeneralSettingsView: View {
 
                 Divider().padding(.vertical, 5).contrast(0.5)
 
+                AnonymousUsageRow()
+
+                Divider().padding(.vertical, 5).contrast(0.5)
+
                 HStack {
                     Text("Shortcut Installation")
                         .frame(width: 150, alignment: .leading)
@@ -529,4 +533,30 @@ private func installShortcut() {
     }
 
     NSWorkspace.shared.open(shortcutUrl)
+}
+
+private struct AnonymousUsageRow: View {
+    @AppStorage(InstallationTracker.analyticsEnabledKey) private var analyticsEnabled: Bool = true
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Anonymous Usage")
+                    .frame(width: 150, alignment: .leading)
+                Spacer()
+                Toggle("", isOn: $analyticsEnabled)
+                    .toggleStyle(SwitchToggleStyle())
+                    .labelsHidden()
+                    .scaleEffect(0.8)
+                    .padding(.trailing, 5)
+            }
+
+            Text("Sends a daily check-in with a random installation ID, app version, macOS version, and license tier so I can see how many people use Auto-Focus. No personal data, no license key, no usage details. Disabling this never affects the app.")
+                .font(.callout)
+                .fontDesign(.default)
+                .fontWeight(.regular)
+                .foregroundColor(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
 }


### PR DESCRIPTION
Sends a daily check-in to the license server with a locally-generated random installation UUID, app version, macOS major.minor, and license tier (free/licensed/beta). No license key, email, or machine fingerprint. Fire-and-forget — any network failure is silently ignored and never affects the app.

Adds an opt-out toggle ("Anonymous Usage") in Configuration → General Settings, defaulting to enabled.

Server endpoint to add: POST https://auto-focus.app/api/v1/installations/check-in